### PR TITLE
Modified the if conditions for omada.tar.gz extraction.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN \
     /tmp/omada.tar.gz -L \
     ${OMADA_DOWNLOAD} && \
   echo "**** unpack omada ****" && \
-  if [ $(tar -tf /tmp/omada.tar.gz | awk -F "\n" '{print $1;exit}' | grep -i "omada") ]; then \
+  if [ $(tar --exclude="*/*" -tf /tmp/omada.tar.gz | grep -i "omada" | awk -F "\n" '{print $1;exit}') ]; then \
     tar xf \
       /tmp/omada.tar.gz -C \
       /tmp/omada/ --strip-components=1; \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/lsio-labs-wide.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-invoiceninja/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Modified the if conditions for omada.tar.gz extraction.
Changed the tar list to exclude subdirectories, and swapped order of "grep" and "awk" - "readme.txt" was the first file listed when using awk before grep, causing false negative and tar not being extracted with --strip-components.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Image now builds successfully with latest Omada SDN Controller (Omada_SDN_Controller_v5.12.7_linux_x64)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using the same if conditions from the dockerfile (determining if there was another sub-directory inside the tarball), which resulted in false negatives and the files in omada.tar.gz to be extracted to the wrong directory. Once the changes were made to the conditions, the if command was catching the subdirectory and extracting to the expected destination. Afterwards, the image able to build.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
